### PR TITLE
Remove Content-Length Header

### DIFF
--- a/spotify.js
+++ b/spotify.js
@@ -156,8 +156,7 @@ class Spotify {
         };
 
         const headers = {
-            ...(await this.getHeaders()),
-            'Content-Length': JSON.stringify(payload).length.toString()
+            ...(await this.getHeaders())
         }
 
         let response = await axios.post(url.toString(), payload, {


### PR DESCRIPTION
The Content-Length header in searchtify is currently being calculated incorrectly.  
It returns an incorrect length when the content includes Korean, Japanese, or Chinese characters, as these are multi-byte. 

This PR removes the manual Content-Length calculation and allows axios to handle it instead.